### PR TITLE
perf: cache file listing, lazy resources/list, Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 WORKDIR /app
 COPY package*.json ./
 RUN npm install

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,15 +18,14 @@ export function configureMcpServerInstance(server: McpServer): void {
     server.registerResource(
         'note',
         new ResourceTemplate('sb-note://{filename}', {
+            // Return an empty resource list.  The full vault (2,500+ notes) is
+            // far too large to enumerate via resources/list on every client
+            // connect — it produces a multi-MB payload through the SSE/stdio
+            // transport.  Clients should use the 'list-notes' tool for
+            // discovery instead.  The resource template still works for
+            // reading individual notes by URI.
             list: async () => {
-                const notesData = await listNotesAPI();
-                const result = {
-                    resources: notesData.map((n) => ({
-                        uri: `sb-note://${encodeURIComponent(n.name)}`,
-                        name: n.name,
-                    })),
-                };
-                return result;
+                return { resources: [] };
             },
         }),
         {

--- a/src/silverbullet-api.ts
+++ b/src/silverbullet-api.ts
@@ -28,59 +28,107 @@ const handleResponseError = async (url: string, response: Response, context: str
     throw new Error(`Failed ${context} from SilverBullet API (${url}): ${response.status} ${response.statusText}`);
 };
 
-export async function listNotesAPI(): Promise<NoteInfo[]> {
-    const url = `${SB_API_BASE_URL}/.fs`;
-    const fetchHeaders = createFetchHeaders();
+// ---------------------------------------------------------------------------
+// Cached file listing (30-second TTL)
+//
+// Both listNotesAPI() and getFullFileListingAPI() delegate to fetchFileListing()
+// so that repeated calls within a session share a single HTTP request to /.fs
+// instead of re-fetching thousands of files every time.  Concurrent callers
+// that hit a cold cache are deduplicated via an in-flight promise.
+//
+// Call invalidateListingCache() after writes/deletes so the next read sees
+// fresh metadata (which in turn lets content caches in cache.ts re-validate).
+// ---------------------------------------------------------------------------
 
-    let response: Response;
-    try {
-        response = await fetch(url, { headers: fetchHeaders });
-    } catch (error) {
-        handleFetchError(url, error);
+const LISTING_TTL_MS = 30_000;
+let listingCache: { files: SBFile[]; timestamp: number } | null = null;
+let listingFetchPromise: Promise<SBFile[]> | null = null;
+
+/**
+ * Invalidate the cached file listing.  Should be called after any write or
+ * delete so subsequent reads observe fresh lastModified timestamps.
+ */
+export function invalidateListingCache(): void {
+    listingCache = null;
+}
+
+async function fetchFileListing(): Promise<SBFile[]> {
+    const now = Date.now();
+
+    // Return cached listing if still fresh
+    if (listingCache && now - listingCache.timestamp < LISTING_TTL_MS) {
+        return listingCache.files;
     }
 
-    if (!response!.ok) {
-        await handleResponseError(url, response!, 'to list notes');
+    // Deduplicate concurrent cold-cache fetches
+    if (listingFetchPromise) {
+        return listingFetchPromise;
     }
 
-    const responseClone = response!.clone();
+    listingFetchPromise = (async () => {
+        const url = `${SB_API_BASE_URL}/.fs`;
+        const fetchHeaders = createFetchHeaders();
 
-    try {
-        const files: SBFile[] = await response!.json();
-        return files
-            .filter((f) => f.name.endsWith('.md') && !f.name.startsWith('Library'))
-            .map((f) => ({ name: f.name, perm: f.perm }));
-    } catch (error) {
-        console.error(`[listNotesAPI] Failed to parse JSON response:`, error);
-
+        let response: Response;
         try {
-            const responseText = await responseClone.text();
-            console.error(`[listNotesAPI] Response body (first 500 chars): ${responseText.substring(0, 500)}`);
-        } catch (textError) {
-            console.error(`[listNotesAPI] Could not read response body as text:`, textError);
+            response = await fetch(url, { headers: fetchHeaders });
+        } catch (error) {
+            handleFetchError(url, error);
         }
 
-        throw new Error(
-            `Failed to parse JSON response from SilverBullet API: ${
-                error instanceof Error ? error.message : String(error)
-            }`
-        );
+        if (!response!.ok) {
+            await handleResponseError(url, response!, 'to list files');
+        }
+
+        const responseClone = response!.clone();
+
+        try {
+            const files: SBFile[] = await response!.json();
+            const filtered = files.filter(
+                (f) => f.name.endsWith('.md') && !f.name.startsWith('Library')
+            );
+            listingCache = { files: filtered, timestamp: Date.now() };
+            return filtered;
+        } catch (error) {
+            console.error(`[fetchFileListing] Failed to parse JSON response:`, error);
+
+            try {
+                const responseText = await responseClone.text();
+                console.error(`[fetchFileListing] Response body (first 500 chars): ${responseText.substring(0, 500)}`);
+            } catch (textError) {
+                console.error(`[fetchFileListing] Could not read response body as text:`, textError);
+            }
+
+            throw new Error(
+                `Failed to parse JSON response from SilverBullet API: ${
+                    error instanceof Error ? error.message : String(error)
+                }`
+            );
+        }
+    })();
+
+    try {
+        return await listingFetchPromise;
+    } finally {
+        listingFetchPromise = null;
     }
 }
 
+/**
+ * Return a lightweight list of notes (name + permission).
+ * Uses the 30-second cached listing.
+ */
+export async function listNotesAPI(): Promise<NoteInfo[]> {
+    const files = await fetchFileListing();
+    return files.map((f) => ({ name: f.name, perm: f.perm }));
+}
+
+/**
+ * Return the full file listing including lastModified, contentType, size, perm.
+ * Uses the 30-second cached listing.
+ */
 export async function getFullFileListingAPI(): Promise<SBFile[]> {
-    const url = `${SB_API_BASE_URL}/.fs`;
-    const fetchHeaders = createFetchHeaders();
-
-    const response = await fetch(url, { headers: fetchHeaders });
-
-    if (!response.ok) {
-        throw new Error(`Failed to get file listing: ${response.status} ${response.statusText}`);
-    }
-
-    const files: SBFile[] = await response.json();
-    const result = files.filter((f) => f.name.endsWith('.md') && !f.name.startsWith('Library'));
-    return result;
+    return fetchFileListing();
 }
 
 export async function readNoteAPI(filename: string): Promise<string> {
@@ -138,6 +186,9 @@ export async function writeNoteAPI(filename: string, content: string): Promise<v
     if (!response!.ok) {
         await handleResponseError(url, response!, `to write note ${filename}`);
     }
+
+    // Invalidate listing cache so subsequent reads see fresh lastModified
+    invalidateListingCache();
 }
 
 export async function deleteNoteAPI(filename: string): Promise<void> {
@@ -158,4 +209,7 @@ export async function deleteNoteAPI(filename: string): Promise<void> {
     if (!response!.ok) {
         await handleResponseError(url, response!, `to delete note ${filename}`);
     }
+
+    // Invalidate listing cache so subsequent reads don't see the deleted file
+    invalidateListingCache();
 }


### PR DESCRIPTION
## Summary

Fixes severe performance issues when the SilverBullet vault contains more than a few hundred notes. In a 2,500+ note vault, every client connection was transferring a multi-megabyte payload and every cached read was slower than a direct one.

## Root Cause

Three issues in the transport/caching layer:

1. **Resources firehose** — `resources/list` called `listNotesAPI()` on every client connect, returning all 2,500+ notes as MCP resources. This produced a multi-MB JSON payload through the SSE/stdio transport on every session init.

2. **Self-defeating cache** — `getCachedNoteContent(filename)` called `getFullFileListingAPI()` (fetching all 2,500+ files) just to check one file lastModified timestamp. Caching a single note was slower than reading it directly.

3. **No listing cache** — `listNotesAPI()` and `getFullFileListingAPI()` both hit the `/.fs` endpoint with zero caching. These are called by `resources/list`, `read-multiple-notes` (validation), `list-notes` tool, and cache checks — each call fetched all 2,500+ files over HTTP.

## Fix

- **Lazy resources/list** — returns `{ resources: [] }` instead of enumerating all notes. The `list-notes` tool is the discovery path. The resource template URI (`sb-note://{filename}`) still works for individual reads.
- **30-second TTL file listing cache** — both `listNotesAPI()` and `getFullFileListingAPI()` now delegate to a shared `fetchFileListing()` with in-flight deduplication (concurrent cold-cache callers share one HTTP request).
- **Cache invalidation on writes** — `writeNoteAPI()` and `deleteNoteAPI()` call `invalidateListingCache()` after mutations.
- **Node 18 → 20** — Node 18 is EOL.

## Changes

- `src/mcp-server.ts`: resources/list callback returns `{ resources: [] }`
- `src/silverbullet-api.ts`: consolidated `fetchFileListing()` with TTL cache + dedup + invalidation
- `Dockerfile`: `FROM node:18` → `FROM node:20`

## Test Coverage

- `npm test`: 107/107 tests pass
- TypeScript build: clean, 0 errors
- Verified on live SilverBullet instance (2,509 notes):

| Operation | Before | After |
|---|---|---|
| `resources/list` | 69ms, 2,503 items | 1ms, 0 items |
| `list-notes` (cold) | ~70ms | 9ms |
| `list-notes` (warm) | ~70ms (no cache) | 7ms |
| `read-multiple-notes` (5 notes) | 80ms | 3ms |
| `read-note` (single) | 11ms | 5ms |

## Test plan

- [x] `npm test` passes (107 tests)
- [x] `npm run build` succeeds
- [x] All 12 MCP tools still functional
- [x] Resource template URI reads still work
- [x] Cache invalidation on write/delete verified